### PR TITLE
Blocking logic moved to suspendScan

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/SuspendBlockingRecoveryModule.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/SuspendBlockingRecoveryModule.java
@@ -3,7 +3,7 @@ package com.arjuna.ats.arjuna.recovery;
 /**
  * If a recovery module implements this interface it allows the recovery manager shutdown to block
  */
-public interface ShutdownBlockingRecoveryModule extends RecoveryModule {
+public interface SuspendBlockingRecoveryModule extends RecoveryModule {
 
     public default boolean shouldBlockShutdown() {
         return false;

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/AtomicActionRecoveryModule.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/AtomicActionRecoveryModule.java
@@ -19,8 +19,7 @@ import com.arjuna.ats.arjuna.objectstore.RecoveryStore;
 import com.arjuna.ats.arjuna.objectstore.StateStatus;
 import com.arjuna.ats.arjuna.objectstore.StoreManager;
 import com.arjuna.ats.arjuna.recovery.RecoverAtomicAction;
-import com.arjuna.ats.arjuna.recovery.RecoveryModule;
-import com.arjuna.ats.arjuna.recovery.ShutdownBlockingRecoveryModule;
+import com.arjuna.ats.arjuna.recovery.SuspendBlockingRecoveryModule;
 import com.arjuna.ats.arjuna.recovery.TransactionStatusConnectionManager;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.internal.arjuna.common.UidHelper;
@@ -31,7 +30,7 @@ import com.arjuna.ats.internal.arjuna.common.UidHelper;
  * It is responsible for recovering failed AtomicAction transactions.
 */
 
-public class AtomicActionRecoveryModule implements ShutdownBlockingRecoveryModule
+public class AtomicActionRecoveryModule implements SuspendBlockingRecoveryModule
 {
    public AtomicActionRecoveryModule()
    {


### PR DESCRIPTION
I moved the blocking logic to `suspendScan`. Moreover, I added a check on `isWaitForFinalRecovery()` to skip waiting the end of the last running scan.